### PR TITLE
dev: add support for setup

### DIFF
--- a/cmd/schema-gen/main.go
+++ b/cmd/schema-gen/main.go
@@ -180,6 +180,10 @@ func structProperties(t reflect.Type) map[string]*Schema {
 }
 
 func goTypeToSchema(t reflect.Type, description string) *Schema {
+	if t.Kind() == reflect.Pointer {
+		return goTypeToSchema(t.Elem(), description)
+	}
+
 	switch t.Kind() {
 	case reflect.String:
 		return &Schema{Type: "string", Description: description}
@@ -201,6 +205,8 @@ func goTypeToSchema(t reflect.Type, description string) *Schema {
 			}
 		}
 		return s
+	case reflect.Struct:
+		return &Schema{Type: "object", Description: description, Properties: structProperties(t)}
 	case reflect.Interface:
 		return &Schema{Description: description}
 	default:
@@ -218,6 +224,17 @@ func fieldDescription(f reflect.StructField) string {
 		"Devices":       "Device configurations",
 		"Description":   "Resource description",
 		"Image":         "Image source for instances (e.g., images:debian/12, docker:caddy)",
+		"Setup":         "Setup actions to run against an instance after create, update, or on every apply",
+		"Action":        "Setup action type",
+		"When":          "When to run the setup action: create, update, or always",
+		"Skip":          "If true, the setup action is skipped",
+		"Command":       "Shell command to execute inside the instance",
+		"CWD":           "Working directory to use for an exec setup action",
+		"Path":          "Absolute destination path inside the instance for a file_push action",
+		"Content":       "Inline file content to push into the instance",
+		"UID":           "File owner uid to set when pushing a file",
+		"GID":           "File owner gid to set when pushing a file",
+		"Mode":          "File mode to set when pushing a file",
 		"VM":            "Create a virtual machine instead of a container",
 		"Empty":         "Create an empty instance (no image)",
 		"Profiles":      "Profiles to apply to the instance",
@@ -228,7 +245,8 @@ func fieldDescription(f reflect.StructField) string {
 		"Ports":         "Optional network forward port rules in the same shape as incus network forward edit",
 		"NetworkType":   "Network type (bridge, ovn, macvlan, sriov, physical)",
 		"Driver":        "Storage driver (dir, zfs, btrfs, lvm, ceph)",
-		"Source":        "Source path or device for storage pool",
+		"Source":        "Source path or device for a storage pool, or a local file path for file_push setup actions",
+		"Recursive":     "Pass --recursive to incus file push for a file_push setup action",
 		"Ingress":       "Ingress firewall rules",
 		"Egress":        "Egress firewall rules",
 	}

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -15,15 +15,77 @@ This page contains the full field reference for `incus-apply` resource documents
 
 ## Instance Fields
 
-| Field      | Type   | Description                                   |
-| ---------- | ------ | --------------------------------------------- |
-| `image`    | string | Image to use (for example `images:debian/12`) |
-| `vm`       | bool   | Create a VM instead of a container            |
-| `empty`    | bool   | Create an empty instance                      |
-| `profiles` | list   | Profiles to apply                             |
-| `storage`  | string | Storage pool for the root disk                |
-| `network`  | string | Network to attach                             |
-| `target`   | string | Cluster member target                         |
+| Field      | Type   | Description                                                    |
+| ---------- | ------ | -------------------------------------------------------------- |
+| `image`    | string | Image to use (for example `images:debian/12`)                  |
+| `vm`       | bool   | Create a VM instead of a container                             |
+| `empty`    | bool   | Create an empty instance                                       |
+| `profiles` | list   | Profiles to apply                                              |
+| `storage`  | string | Storage pool for the root disk                                 |
+| `network`  | string | Network to attach                                              |
+| `target`   | string | Cluster member target                                          |
+| `setup`    | list   | Post-create and post-update actions to run inside the instance |
+
+### Instance Setup Actions
+
+Use `setup` to run imperative instance actions after Incus resource changes are applied.
+
+- `when: create` runs only when the instance is created or recreated.
+- `when: update` runs on create and on later applies when the instance changes.
+- `when: always` runs on every apply, even when the instance config itself is unchanged.
+- `skip: true` keeps the action in config but prevents execution.
+
+Supported actions:
+
+| Field       | Type    | Description                                                                                |
+| ----------- | ------- | ------------------------------------------------------------------------------------------ |
+| `action`    | string  | **Required.** `exec` or `file_push`                                                        |
+| `when`      | string  | **Required.** `create`, `update`, or `always`                                              |
+| `skip`      | boolean | Skip the action without removing it from config                                            |
+| `command`   | string  | Required for `action: exec`; executed as root using `sh -c <command>`                      |
+| `cwd`       | string  | Optional working directory for `action: exec`; passed to `incus exec --cwd`                |
+| `path`      | string  | Required for `action: file_push`; absolute path inside the instance                        |
+| `content`   | string  | Inline file content for `file_push`                                                        |
+| `source`    | string  | Local source path for `file_push`; relative paths are resolved from the owning config file |
+| `recursive` | boolean | Optional for `file_push`; passes `--recursive` to `incus file push` when `source` is used  |
+| `uid`       | integer | Optional file owner uid for `file_push`                                                    |
+| `gid`       | integer | Optional file owner gid for `file_push`                                                    |
+| `mode`      | string  | Optional file mode for `file_push`                                                         |
+
+Notes:
+
+- `file_push` requires exactly one of `content` or `source`.
+- `file_push.source` is passed to `incus file push` as-is after relative-path resolution. `incus-apply` validates that it exists when the action executes, but does not read it.
+- Use `recursive: true` with `file_push.source` when pushing directories or when you want `incus file push --recursive`.
+- `exec` actions run as the root user inside the instance unless Incus defaults are changed elsewhere.
+- `exec` actions always run non-interactively and use `sh -c` so shell syntax works as expected.
+- Relative `source` paths are resolved from the configuration file location. Absolute paths are also supported.
+- Relative `source` paths are not supported when applying config from stdin or a URL.
+- Changes to `when: create` actions are treated as recreate-required for managed instances, because those actions cannot be replayed on a normal update.
+
+### Example
+
+```yaml
+type: instance
+name: web
+image: images:debian/12
+setup:
+  - action: exec
+    when: create
+    cwd: /root
+    command: apt-get update && apt-get install -y nginx
+  - action: file_push
+    when: update
+    path: /etc/caddy/Caddyfile
+    source: ./Caddyfile
+    recursive: true
+    uid: 0
+    gid: 0
+    mode: "0644"
+  - action: exec
+    when: always
+    command: systemctl restart caddy
+```
 
 ## Storage Pool Fields
 

--- a/examples/wordpress.incus.yaml
+++ b/examples/wordpress.incus.yaml
@@ -1,6 +1,6 @@
-# WordPress on a single container with cloud-init
+# WordPress on a single container with setup actions
 #
-# Sets up MySQL, Caddy, and WordPress on an Ubuntu container using cloud-init.
+# Sets up MySQL, Caddy, and WordPress on an Ubuntu container using setup actions.
 # WordPress will be available on port 80 of the container.
 ---
 type: vars
@@ -19,90 +19,87 @@ description: Persistent storage for MySQL data
 ---
 type: instance
 name: wordpress
-image: images:ubuntu/24.04/cloud
+image: images:ubuntu/24.04
 config:
   limits.cpu: "2"
   limits.memory: 2GiB
-  cloud-init.user-data: |
-    #cloud-config
-    package_update: true
-    packages:
-      - mysql-server
-      - php-fpm
-      - php-mysql
-      - php-curl
-      - php-gd
-      - php-xml
-      - php-mbstring
-      - curl
-      - debian-keyring
-      - debian-archive-keyring
-      - apt-transport-https
-
-    write_files:
-      - path: /tmp/Caddyfile
-        permissions: "0644"
-        content: |
-          :80 {
-            root * /var/www/html
-            php_fastcgi unix//run/php/php-fpm.sock
-            file_server
-            log {
-              output file /var/log/caddy/access.log
-            }
-          }
-
-      - path: /tmp/setup-wordpress.sh
-        permissions: "0755"
-        content: |
-          #!/bin/bash
-          set -e
-
-          # Install Caddy
-          curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-          curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
-          apt-get update
-          apt-get install -y caddy
-
-          # Replace default Caddyfile
-          cp /tmp/Caddyfile /etc/caddy/Caddyfile
-
-          # Configure MySQL
-          mysql -e "CREATE DATABASE IF NOT EXISTS $MYSQL_DATABASE;"
-          mysql -e "CREATE USER IF NOT EXISTS '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD';"
-          mysql -e "GRANT ALL PRIVILEGES ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'localhost';"
-          mysql -e "FLUSH PRIVILEGES;"
-
-          # Install WordPress
-          mkdir -p /var/www/html
-          curl -sL https://wordpress.org/latest.tar.gz | tar xz -C /var/www/html --strip-components=1
-
-          # Configure WordPress
-          cp /var/www/html/wp-config-sample.php /var/www/html/wp-config.php
-          sed -i "s/database_name_here/$MYSQL_DATABASE/" /var/www/html/wp-config.php
-          sed -i "s/username_here/$MYSQL_USER/" /var/www/html/wp-config.php
-          sed -i "s/password_here/$MYSQL_PASSWORD/" /var/www/html/wp-config.php
-
-          # Generate unique salts
-          curl -sL https://api.wordpress.org/secret-key/1.1/salt/ > /tmp/wp-salts.php
-          sed -i "/put your unique phrase here/d" /var/www/html/wp-config.php
-          sed -i "/That's all, stop editing/r /tmp/wp-salts.php" /var/www/html/wp-config.php
-
-          # Set ownership and permissions
-          chown -R www-data:www-data /var/www/html
-
-          systemctl restart php*-fpm
-          systemctl enable caddy
-          systemctl restart caddy
-
-    runcmd:
-      - systemctl enable mysql
-      - systemctl start mysql
-      - /tmp/setup-wordpress.sh
 devices:
   mysql-data:
     type: disk
     pool: default
     source: mysql-data
     path: /var/lib/mysql
+
+setup:
+  - action: exec
+    when: create
+    command: |
+      set -e
+      export DEBIAN_FRONTEND=noninteractive
+
+      apt-get update
+      apt-get install -y \
+        mysql-server \
+        php-fpm \
+        php-mysql \
+        php-curl \
+        php-gd \
+        php-xml \
+        php-mbstring \
+        curl \
+        gpg \
+        debian-keyring \
+        debian-archive-keyring \
+        apt-transport-https
+
+      curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+      curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
+      apt-get update
+      apt-get install -y caddy
+
+      systemctl enable mysql
+      systemctl start mysql
+
+      mysql -e "CREATE DATABASE IF NOT EXISTS $MYSQL_DATABASE;"
+      mysql -e "CREATE USER IF NOT EXISTS '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD';"
+      mysql -e "GRANT ALL PRIVILEGES ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'localhost';"
+      mysql -e "FLUSH PRIVILEGES;"
+
+      mkdir -p /var/www/html
+      curl -sL https://wordpress.org/latest.tar.gz | tar xz -C /var/www/html --strip-components=1
+
+      cp /var/www/html/wp-config-sample.php /var/www/html/wp-config.php
+      sed -i "s/database_name_here/$MYSQL_DATABASE/" /var/www/html/wp-config.php
+      sed -i "s/username_here/$MYSQL_USER/" /var/www/html/wp-config.php
+      sed -i "s/password_here/$MYSQL_PASSWORD/" /var/www/html/wp-config.php
+
+      curl -sL https://api.wordpress.org/secret-key/1.1/salt/ > /tmp/wp-salts.php
+      sed -i "/put your unique phrase here/d" /var/www/html/wp-config.php
+      sed -i "/That's all, stop editing/r /tmp/wp-salts.php" /var/www/html/wp-config.php
+
+      chown -R www-data:www-data /var/www/html
+
+      systemctl restart php*-fpm
+      systemctl enable caddy
+
+  # Keep the Caddyfile in sync after the base setup is in place.
+  - action: file_push
+    when: update
+    path: /etc/caddy/Caddyfile
+    mode: "0644"
+    content: |
+      :80 {
+        root * /var/www/html
+        php_fastcgi unix//run/php/php-fpm.sock
+        file_server
+        log {
+          output file /var/log/caddy/access.log
+        }
+      }
+
+  # Reload Caddy after its config has been written.
+  - action: exec
+    when: update
+    command: systemctl restart caddy
+
 description: WordPress with Caddy and MySQL on a single Ubuntu container

--- a/internal/apply/diff.go
+++ b/internal/apply/diff.go
@@ -50,6 +50,9 @@ func computeUpsertDiff(opts *Options, client incus.Client, resources []*config.R
 			if resource.Type(res.Type) == resource.TypeInstance && opts.Launch {
 				item.Note = "launch"
 			}
+			if hasSetupForCreate(res) {
+				item.Note = appendNote(item.Note, "setup")
+			}
 			creates = append(creates, item)
 			preview.created++
 			plans = append(plans, upsertPlan{res: res, action: upsertCreate})
@@ -78,6 +81,9 @@ func computeUpsertDiff(opts *Options, client incus.Client, resources []*config.R
 			if opts.Stop && resource.Type(res.Type) == resource.TypeInstance && client.Running(res) {
 				item.Note = "restart"
 			}
+			if hasSetupForUpdate(res) {
+				item.Note = appendNote(item.Note, "setup")
+			}
 			if !status.Managed && status.Warning != "" {
 				printWarning(opts.Quiet, "Warning: %s was not created by incus-apply; falling back to live-state diff and update behavior.", resourceID)
 				item.Note = appendNote(item.Note, status.Warning)
@@ -99,6 +105,10 @@ func computeUpsertDiff(opts *Options, client incus.Client, resources []*config.R
 			updates = append(updates, item)
 			preview.updated++
 			plans = append(plans, upsertPlan{res: res, action: upsertUpdate})
+		} else if hasSetupForAlways(res) {
+			updates = append(updates, OutputItem{ResourceID: resourceID, Note: "setup"})
+			preview.updated++
+			plans = append(plans, upsertPlan{res: res, action: upsertSetupOnly})
 		} else {
 			unchanged = append(unchanged, OutputItem{ResourceID: resourceID})
 			preview.unchanged++
@@ -182,6 +192,44 @@ func shouldRedactPreviewPath(path string, prefixes []string) bool {
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(path, prefix) {
 			return true
+		}
+	}
+	return false
+}
+
+func hasSetupForCreate(res *config.Resource) bool {
+	return hasSetupForAction(res, upsertCreate)
+}
+
+func hasSetupForUpdate(res *config.Resource) bool {
+	return hasSetupForAction(res, upsertUpdate)
+}
+
+func hasSetupForAlways(res *config.Resource) bool {
+	return hasSetupForAction(res, upsertSetupOnly)
+}
+
+func hasSetupForAction(res *config.Resource, action upsertAction) bool {
+	if resource.Type(res.Type) != resource.TypeInstance {
+		return false
+	}
+	for _, setup := range res.Setup {
+		if setup.Skip {
+			continue
+		}
+		switch action {
+		case upsertCreate, upsertReplace:
+			if setup.When == config.SetupWhenCreate || setup.When == config.SetupWhenUpdate || setup.When == config.SetupWhenAlways {
+				return true
+			}
+		case upsertUpdate:
+			if setup.When == config.SetupWhenUpdate || setup.When == config.SetupWhenAlways {
+				return true
+			}
+		case upsertSetupOnly:
+			if setup.When == config.SetupWhenAlways {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/apply/executor_flow_test.go
+++ b/internal/apply/executor_flow_test.go
@@ -27,6 +27,7 @@ type fakeClient struct {
 	startCalls  []string
 	stopCalls   []string
 	updateCalls []string
+	setupCalls  []string
 }
 
 func newFakeClient() *fakeClient {
@@ -96,6 +97,12 @@ func (c *fakeClient) Running(res *config.Resource) bool {
 	return c.running[formatResourceID(res)]
 }
 
+func (c *fakeClient) RunSetupAction(res *config.Resource, action config.SetupAction, current, total int) *incus.Result {
+	key := formatResourceID(res)
+	c.setupCalls = append(c.setupCalls, key+":"+string(action.Action)+":"+string(action.When))
+	return &incus.Result{}
+}
+
 type captureRenderer struct {
 	outputs []Output
 }
@@ -139,6 +146,69 @@ func TestExecutorUpsertCreatesAndStartsInstance(t *testing.T) {
 	}
 	if got := renderer.outputs[0].Groups[0].Items[0].Note; got != "launch" {
 		t.Fatalf("note = %q, want %q", got, "launch")
+	}
+}
+
+func TestExecutorUpsertCreateRunsSetupActions(t *testing.T) {
+	dir := t.TempDir()
+	path := writeConfigFile(t, dir, "instance.incus.yaml", "type: instance\nname: web\nimage: images:alpine/3.19\nsetup:\n  - action: exec\n    when: create\n    command: echo create\n  - action: file_push\n    when: update\n    path: /etc/app.conf\n    content: hi\n  - action: exec\n    when: always\n    command: echo always\n  - action: exec\n    when: always\n    skip: true\n    command: echo skip\n")
+
+	client := newFakeClient()
+	renderer := &captureRenderer{}
+	executor := NewExecutor(Options{Files: []string{path}, Yes: true, Quiet: true}, client, renderer)
+
+	if err := executor.Upsert(); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	if len(client.createCalls) != 1 || client.createCalls[0] != "default:instance/web" {
+		t.Fatalf("create calls = %v, want [default:instance/web]", client.createCalls)
+	}
+	if len(client.startCalls) != 1 || client.startCalls[0] != "default:instance/web" {
+		t.Fatalf("start calls = %v, want [default:instance/web]", client.startCalls)
+	}
+	if len(client.stopCalls) != 1 || client.stopCalls[0] != "default:instance/web" {
+		t.Fatalf("stop calls = %v, want [default:instance/web]", client.stopCalls)
+	}
+	wantSetup := []string{
+		"default:instance/web:exec:create",
+		"default:instance/web:file_push:update",
+		"default:instance/web:exec:always",
+	}
+	if strings.Join(client.setupCalls, ",") != strings.Join(wantSetup, ",") {
+		t.Fatalf("setup calls = %v, want %v", client.setupCalls, wantSetup)
+	}
+	if got := renderer.outputs[0].Groups[0].Items[0].Note; got != "setup" {
+		t.Fatalf("note = %q, want %q", got, "setup")
+	}
+	if len(client.startCalls) != 1 {
+		t.Fatalf("unexpected launch start calls = %v", client.startCalls)
+	}
+}
+
+func TestExecutorUpsertAlwaysSetupRunsWithoutConfigUpdate(t *testing.T) {
+	dir := t.TempDir()
+	path := writeConfigFile(t, dir, "instance.incus.yaml", "type: instance\nname: web\nimage: images:alpine/3.19\nsetup:\n  - action: exec\n    when: always\n    command: echo always\n")
+
+	client := newFakeClient()
+	client.exists["default:instance/web"] = true
+	client.current["default:instance/web"] = "config:\n  user.incus-apply.created: \"true\"\n  user.incus-apply.current: '{\"image\":\"images:alpine/3.19\",\"setup\":[{\"action\":\"exec\",\"when\":\"always\",\"command\":\"hash: 9e4ad387b7ad3a5d1a10fb6211\"}]}'\n"
+	renderer := &captureRenderer{}
+	executor := NewExecutor(Options{Files: []string{path}, Yes: true, Quiet: true}, client, renderer)
+
+	if err := executor.Upsert(); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	if len(client.updateCalls) != 0 {
+		t.Fatalf("update calls = %v, want none", client.updateCalls)
+	}
+	if len(client.startCalls) != 1 || len(client.stopCalls) != 1 {
+		t.Fatalf("start/stop calls = %v/%v, want one temporary cycle", client.startCalls, client.stopCalls)
+	}
+	if len(client.setupCalls) != 1 || client.setupCalls[0] != "default:instance/web:exec:always" {
+		t.Fatalf("setup calls = %v, want one always exec", client.setupCalls)
+	}
+	if got := renderer.outputs[0].Summary; got != "Summary: 1 to update." {
+		t.Fatalf("summary = %q, want %q", got, "Summary: 1 to update.")
 	}
 }
 

--- a/internal/apply/runner.go
+++ b/internal/apply/runner.go
@@ -1,6 +1,8 @@
 package apply
 
 import (
+	"strconv"
+
 	"github.com/abiosoft/incus-apply/internal/config"
 	"github.com/abiosoft/incus-apply/internal/incus"
 	"github.com/abiosoft/incus-apply/internal/resource"
@@ -10,10 +12,11 @@ import (
 type upsertAction int
 
 const (
-	upsertSkip    upsertAction = iota // no changes detected
-	upsertCreate                      // resource does not exist
-	upsertUpdate                      // resource exists and has changes
-	upsertReplace                     // resource must be deleted and recreated
+	upsertSkip      upsertAction = iota // no changes detected
+	upsertCreate                        // resource does not exist
+	upsertUpdate                        // resource exists and has changes
+	upsertReplace                       // resource must be deleted and recreated
+	upsertSetupOnly                     // setup runs without a config diff
 )
 
 // upsertPlan captures the create/update/skip decisions made during the diff
@@ -52,6 +55,8 @@ func (r *runner) upsert(plan upsertPlan) error {
 		return r.update(plan.res, formatResourceID(plan.res))
 	case upsertReplace:
 		return r.replace(plan.res, formatResourceID(plan.res))
+	case upsertSetupOnly:
+		return r.setupOnly(plan.res, formatResourceID(plan.res))
 	default: // upsertSkip
 		r.result.unchanged++
 		return nil
@@ -69,24 +74,30 @@ func (r *runner) replace(res *config.Resource, resourceID string) error {
 	}
 	printColored(r.opts.Quiet, colorYellow, "! %s replaced", resourceID)
 	r.result.replaced++
-
-	if resource.Type(res.Type) == resource.TypeInstance && r.opts.Launch {
-		startResult := r.client.Start(res)
-		if startResult.Error != nil {
-			return r.result.recordError(r.opts.FailFast, resourceID, "start failed", startResult.Error)
-		}
-	}
-
-	return nil
+	return r.finishCreatedInstance(res, resourceID, upsertReplace)
 }
 
 // update applies an update for a resource that was already confirmed to have changes.
 func (r *runner) update(res *config.Resource, resourceID string) error {
+	wasRunning := resource.Type(res.Type) == resource.TypeInstance && r.client.Running(res)
 	result := r.client.Update(res)
 	if result.Error != nil {
 		return r.result.recordError(r.opts.FailFast, resourceID, "update failed", result.Error)
 	}
 	printColored(r.opts.Quiet, colorYellow, "~ %s updated", resourceID)
+	r.result.updated++
+	if err := r.runSetupForExistingInstance(res, resourceID, upsertUpdate, wasRunning); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *runner) setupOnly(res *config.Resource, resourceID string) error {
+	wasRunning := resource.Type(res.Type) == resource.TypeInstance && r.client.Running(res)
+	if err := r.runSetupForExistingInstance(res, resourceID, upsertSetupOnly, wasRunning); err != nil {
+		return err
+	}
+	printColored(r.opts.Quiet, colorYellow, "~ %s setup applied", resourceID)
 	r.result.updated++
 	return nil
 }
@@ -99,17 +110,103 @@ func (r *runner) create(res *config.Resource, resourceID string) error {
 	}
 	printColored(r.opts.Quiet, colorGreen, "+ %s created", resourceID)
 	r.result.created++
+	return r.finishCreatedInstance(res, resourceID, upsertCreate)
+}
 
-	// Start newly created instances unless --launch=false
-	if resource.Type(res.Type) == resource.TypeInstance && r.opts.Launch {
-		startResult := r.client.Start(res)
-		if startResult.Error != nil {
-			return r.result.recordError(r.opts.FailFast, resourceID, "start failed", startResult.Error)
-		} else {
-			printInfo(r.opts.Quiet, "  └─ started")
+func (r *runner) finishCreatedInstance(res *config.Resource, resourceID string, action upsertAction) error {
+	if resource.Type(res.Type) != resource.TypeInstance {
+		return nil
+	}
+
+	needsSetup := hasSetupForAction(res, action)
+	if !r.opts.Launch && !needsSetup {
+		return nil
+	}
+
+	startResult := r.client.Start(res)
+	if startResult.Error != nil {
+		return r.result.recordError(r.opts.FailFast, resourceID, "start failed", startResult.Error)
+	}
+	if r.opts.Launch {
+		printInfo(r.opts.Quiet, "  └─ started")
+	}
+
+	if err := r.runSetupActions(res, resourceID, action); err != nil {
+		if !r.opts.Launch {
+			_ = r.client.Stop(res)
+		}
+		return err
+	}
+
+	if !r.opts.Launch {
+		stopResult := r.client.Stop(res)
+		if stopResult.Error != nil {
+			return r.result.recordError(r.opts.FailFast, resourceID, "stop after setup failed", stopResult.Error)
 		}
 	}
 	return nil
+}
+
+func (r *runner) runSetupForExistingInstance(res *config.Resource, resourceID string, action upsertAction, wasRunning bool) error {
+	if resource.Type(res.Type) != resource.TypeInstance || !hasSetupForAction(res, action) {
+		return nil
+	}
+	if wasRunning {
+		return r.runSetupActions(res, resourceID, action)
+	}
+
+	startResult := r.client.Start(res)
+	if startResult.Error != nil {
+		return r.result.recordError(r.opts.FailFast, resourceID, "start for setup failed", startResult.Error)
+	}
+	if err := r.runSetupActions(res, resourceID, action); err != nil {
+		_ = r.client.Stop(res)
+		return err
+	}
+	stopResult := r.client.Stop(res)
+	if stopResult.Error != nil {
+		return r.result.recordError(r.opts.FailFast, resourceID, "stop after setup failed", stopResult.Error)
+	}
+	return nil
+}
+
+func (r *runner) runSetupActions(res *config.Resource, resourceID string, action upsertAction) error {
+	total := 0
+	for _, setup := range res.Setup {
+		if shouldRunSetupAction(setup, action) {
+			total++
+		}
+	}
+
+	current := 0
+	for index, setup := range res.Setup {
+		if !shouldRunSetupAction(setup, action) {
+			continue
+		}
+		current++
+		result := r.client.RunSetupAction(res, setup, current, total)
+		if result.Error != nil {
+			return r.result.recordError(r.opts.FailFast, resourceID, "setup["+strconv.Itoa(index)+"] "+string(setup.Action)+" failed", result.Error)
+		}
+	}
+	return nil
+}
+
+func shouldRunSetupAction(setup config.SetupAction, action upsertAction) bool {
+	if setup.Skip {
+		return false
+	}
+
+	switch action {
+	case upsertCreate, upsertReplace:
+		return setup.When == config.SetupWhenCreate || setup.When == config.SetupWhenUpdate || setup.When == config.SetupWhenAlways
+	case upsertUpdate:
+		return setup.When == config.SetupWhenUpdate || setup.When == config.SetupWhenAlways
+	case upsertSetupOnly:
+		return setup.When == config.SetupWhenAlways
+	default:
+		return false
+	}
 }
 
 // delete handles deletion of a single resource based on the pre-computed plan.

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -95,3 +95,43 @@ ports:
 		t.Fatalf("ports = %#v, want one rule", res.Ports)
 	}
 }
+
+func TestParseInstanceSetupFields(t *testing.T) {
+	input := "type: instance\n" +
+		"name: web\n" +
+		"image: images:alpine/3.19\n" +
+		"setup:\n" +
+		"  - action: exec\n" +
+		"    when: create\n" +
+		"    cwd: /root\n" +
+		"    command: echo hi\n" +
+		"  - action: file_push\n" +
+		"    when: update\n" +
+		"    path: /etc/app.conf\n" +
+		"    source: ./app.conf\n" +
+		"    recursive: true\n" +
+		"    uid: 0\n" +
+		"    gid: 0\n" +
+		"    mode: \"0644\"\n"
+
+	result, err := NewParser(0).ParseStdin(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("ParseStdin() error = %v", err)
+	}
+	res := result.Resources[0]
+	if len(res.Setup) != 2 {
+		t.Fatalf("setup = %#v, want 2 actions", res.Setup)
+	}
+	if res.Setup[0].Action != SetupActionExec || res.Setup[0].When != SetupWhenCreate {
+		t.Fatalf("first setup action = %#v, want exec/create", res.Setup[0])
+	}
+	if res.Setup[0].CWD != "/root" {
+		t.Fatalf("cwd = %q, want /root", res.Setup[0].CWD)
+	}
+	if res.Setup[1].Mode != "0644" {
+		t.Fatalf("mode = %q, want 0644", res.Setup[1].Mode)
+	}
+	if !res.Setup[1].Recursive {
+		t.Fatal("recursive = false, want true")
+	}
+}

--- a/internal/config/setup.go
+++ b/internal/config/setup.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const setupHashLength = 26
+const setupHashPrefix = "hash: "
+
+func ResolveSetupSourcePath(source, sourceFile string) (string, error) {
+	if source == "" {
+		return "", nil
+	}
+	if filepath.IsAbs(source) {
+		return source, nil
+	}
+	if sourceFile == "" {
+		return "", fmt.Errorf("relative setup source %q requires a source file", source)
+	}
+	if sourceFile == "stdin" || strings.HasPrefix(sourceFile, "http://") || strings.HasPrefix(sourceFile, "https://") {
+		return "", fmt.Errorf("relative setup source %q is not supported for %s", source, sourceFile)
+	}
+
+	resolved := filepath.Join(filepath.Dir(sourceFile), source)
+	abs, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolving setup source %q: %w", source, err)
+	}
+	return abs, nil
+}
+
+func SetupActionSnapshot(action SetupAction, sourceFile string) (map[string]any, error) {
+	state := map[string]any{
+		"action": action.Action,
+		"when":   action.When,
+	}
+	if action.Skip {
+		state["skip"] = true
+	}
+
+	switch action.Action {
+	case SetupActionExec:
+		state["command"] = setupHashValue(action.Command)
+		if action.CWD != "" {
+			state["cwd"] = action.CWD
+		}
+	case SetupActionPushFile:
+		state["path"] = action.Path
+		if action.Content != "" {
+			state["content"] = setupHashValue(action.Content)
+		}
+		if action.Source != "" {
+			state["source"] = action.Source
+		}
+		if action.Recursive {
+			state["recursive"] = true
+		}
+		if action.UID != nil {
+			state["uid"] = *action.UID
+		}
+		if action.GID != nil {
+			state["gid"] = *action.GID
+		}
+		if action.Mode != "" {
+			state["mode"] = string(action.Mode)
+		}
+	}
+
+	return state, nil
+}
+
+func sha256Hex(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}
+
+// setupHashValue stores a shortened digest with the original character count
+// spliced into the end, for example: "hash: 7772eeb2b835fcacc5f43ce103".
+func setupHashValue(text string) string {
+	hash := sha256Hex(text)
+	lengthSuffix := strconv.Itoa(utf8.RuneCountInString(text))
+	if len(lengthSuffix) >= setupHashLength {
+		return fmt.Sprintf("%s%s", setupHashPrefix, lengthSuffix[len(lengthSuffix)-setupHashLength:])
+	}
+	prefixLength := setupHashLength - len(lengthSuffix)
+	return fmt.Sprintf("%s%s%s", setupHashPrefix, hash[:prefixLength], lengthSuffix)
+}
+
+func ValidateSetupSource(action SetupAction, sourceFile string) error {
+	if action.Source == "" {
+		return nil
+	}
+	resolved, err := ResolveSetupSourcePath(action.Source, sourceFile)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(resolved); err != nil {
+		return fmt.Errorf("checking setup source %q: %w", resolved, err)
+	}
+	return nil
+}

--- a/internal/config/setup_test.go
+++ b/internal/config/setup_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveSetupSourcePathRelativeToConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "instance.incus.yaml")
+	resolved, err := ResolveSetupSourcePath("./files/Caddyfile", configPath)
+	if err != nil {
+		t.Fatalf("ResolveSetupSourcePath() error = %v", err)
+	}
+	want := filepath.Join(dir, "files", "Caddyfile")
+	if resolved != want {
+		t.Fatalf("resolved = %q, want %q", resolved, want)
+	}
+}
+
+func TestResolveSetupSourcePathRejectsRelativeStdinSource(t *testing.T) {
+	_, err := ResolveSetupSourcePath("./files/Caddyfile", "stdin")
+	if err == nil {
+		t.Fatal("ResolveSetupSourcePath() error = nil, want non-nil")
+	}
+}
+
+func TestValidateSetupSourceAcceptsExistingPath(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "instance.incus.yaml")
+	sourcePath := filepath.Join(dir, "files", "Caddyfile")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	if err := ValidateSetupSource(SetupAction{Source: "./files/Caddyfile"}, configPath); err != nil {
+		t.Fatalf("ValidateSetupSource() error = %v", err)
+	}
+}
+
+func TestValidateSetupSourceRejectsMissingPath(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "instance.incus.yaml")
+	err := ValidateSetupSource(SetupAction{Source: "./files/Caddyfile"}, configPath)
+	if err == nil {
+		t.Fatal("ValidateSetupSource() error = nil, want non-nil")
+	}
+}
+
+func TestSetupActionSnapshotHashesInlineContent(t *testing.T) {
+	action := SetupAction{
+		Action:  SetupActionPushFile,
+		When:    SetupWhenUpdate,
+		Path:    "/etc/app.conf",
+		Content: "hello world",
+	}
+
+	snapshot, err := SetupActionSnapshot(action, "")
+	if err != nil {
+		t.Fatalf("SetupActionSnapshot() error = %v", err)
+	}
+	if _, ok := snapshot["content"]; ok {
+		if snapshot["content"] == "hello world" {
+			t.Fatalf("snapshot = %#v, want raw content omitted", snapshot)
+		}
+	}
+	sum := sha256.Sum256([]byte("hello world"))
+	want := setupHashPrefix + hex.EncodeToString(sum[:])[:setupHashLength-2] + "11"
+	if snapshot["content"] != want {
+		t.Fatalf("content = %v, want %q", snapshot["content"], want)
+	}
+}
+
+func TestSetupActionSnapshotHashesExecCommand(t *testing.T) {
+	action := SetupAction{
+		Action:  SetupActionExec,
+		When:    SetupWhenAlways,
+		Command: "echo hello world",
+	}
+
+	snapshot, err := SetupActionSnapshot(action, "")
+	if err != nil {
+		t.Fatalf("SetupActionSnapshot() error = %v", err)
+	}
+	if _, ok := snapshot["command"]; ok {
+		if snapshot["command"] == "echo hello world" {
+			t.Fatalf("snapshot = %#v, want raw command omitted", snapshot)
+		}
+	}
+	sum := sha256.Sum256([]byte("echo hello world"))
+	want := setupHashPrefix + hex.EncodeToString(sum[:])[:setupHashLength-2] + "16"
+	if snapshot["command"] != want {
+		t.Fatalf("command = %v, want %q", snapshot["command"], want)
+	}
+}
+
+func TestSetupHashValueEmbedsOriginalLength(t *testing.T) {
+	value := strings.Repeat("x", 103)
+	hash := sha256.Sum256([]byte(value))
+	want := setupHashPrefix + hex.EncodeToString(hash[:])[:setupHashLength-3] + "103"
+	if got := setupHashValue(value); got != want {
+		t.Fatalf("setupHashValue() = %q, want %q", got, want)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,6 +1,10 @@
 // Package config handles parsing and validation of incus-apply configuration files.
 package config
 
+import (
+	"fmt"
+)
+
 // Base contains fields common to all Incus resource types.
 type Base struct {
 	Type        string                    `yaml:"type" json:"type"`                                   // Resource type: instance, profile, network, etc.
@@ -29,13 +33,47 @@ type Resource struct {
 
 // InstanceFields captures the fields specific to Incus instances.
 type InstanceFields struct {
-	Image    string   `yaml:"image,omitempty" json:"image,omitempty"`
-	VM       bool     `yaml:"vm,omitempty" json:"vm,omitempty"`
-	Empty    bool     `yaml:"empty,omitempty" json:"empty,omitempty"`
-	Profiles []string `yaml:"profiles,omitempty" json:"profiles,omitempty"`
-	Storage  string   `yaml:"storage,omitempty" json:"storage,omitempty"`
-	Network  string   `yaml:"network,omitempty" json:"network,omitempty"`
-	Target   string   `yaml:"target,omitempty" json:"target,omitempty"`
+	Image    string        `yaml:"image,omitempty" json:"image,omitempty"`
+	VM       bool          `yaml:"vm,omitempty" json:"vm,omitempty"`
+	Empty    bool          `yaml:"empty,omitempty" json:"empty,omitempty"`
+	Profiles []string      `yaml:"profiles,omitempty" json:"profiles,omitempty"`
+	Storage  string        `yaml:"storage,omitempty" json:"storage,omitempty"`
+	Network  string        `yaml:"network,omitempty" json:"network,omitempty"`
+	Target   string        `yaml:"target,omitempty" json:"target,omitempty"`
+	Setup    []SetupAction `yaml:"setup,omitempty" json:"setup,omitempty"`
+}
+
+// SetupActionType identifies the supported setup action kinds.
+type SetupActionType string
+
+const (
+	SetupActionExec     SetupActionType = "exec"
+	SetupActionPushFile SetupActionType = "file_push"
+)
+
+// SetupWhen controls when a setup action runs during apply.
+type SetupWhen string
+
+const (
+	SetupWhenCreate SetupWhen = "create"
+	SetupWhenUpdate SetupWhen = "update"
+	SetupWhenAlways SetupWhen = "always"
+)
+
+// SetupAction defines an imperative action to run against an instance.
+type SetupAction struct {
+	Action    SetupActionType `yaml:"action" json:"action"`
+	When      SetupWhen       `yaml:"when" json:"when"`
+	Skip      bool            `yaml:"skip,omitempty" json:"skip,omitempty"`
+	Command   string          `yaml:"command,omitempty" json:"command,omitempty"`
+	CWD       string          `yaml:"cwd,omitempty" json:"cwd,omitempty"`
+	Path      string          `yaml:"path,omitempty" json:"path,omitempty"`
+	Content   string          `yaml:"content,omitempty" json:"content,omitempty"`
+	Source    string          `yaml:"source,omitempty" json:"source,omitempty"`
+	Recursive bool            `yaml:"recursive,omitempty" json:"recursive,omitempty"`
+	UID       *int            `yaml:"uid,omitempty" json:"uid,omitempty"`
+	GID       *int            `yaml:"gid,omitempty" json:"gid,omitempty"`
+	Mode      string          `yaml:"mode,omitempty" json:"mode,omitempty"`
 }
 
 // StoragePoolFields captures the fields specific to storage pools.
@@ -83,15 +121,59 @@ func (r Resource) Validate() error {
 	if r.Type == "" {
 		return &ValidationError{Field: "type", Message: "type is required"}
 	}
+	if len(r.Setup) > 0 && r.Type != "instance" {
+		return &ValidationError{Field: "setup", Message: "setup is only supported for instances"}
+	}
 	if r.Type == "network-forward" {
 		if r.ListenAddress == "" {
 			return &ValidationError{Field: "listen_address", Message: "listen_address is required"}
 		}
-		return nil
-	}
-	if r.Type != "vars" && r.Name == "" {
+	} else if r.Type != "vars" && r.Name == "" {
 		return &ValidationError{Field: "name", Message: "name is required"}
 	}
+	for i, action := range r.Setup {
+		if err := action.Validate(i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a SetupAction) Validate(index int) error {
+	field := func(name string) string {
+		return fmt.Sprintf("setup[%d].%s", index, name)
+	}
+
+	switch a.When {
+	case SetupWhenCreate, SetupWhenUpdate, SetupWhenAlways:
+	case "":
+		return &ValidationError{Field: field("when"), Message: "when is required"}
+	default:
+		return &ValidationError{Field: field("when"), Message: "when must be one of create, update, always"}
+	}
+
+	switch a.Action {
+	case SetupActionExec:
+		if a.Command == "" {
+			return &ValidationError{Field: field("command"), Message: "command is required for exec actions"}
+		}
+	case SetupActionPushFile:
+		if a.Path == "" {
+			return &ValidationError{Field: field("path"), Message: "path is required for file_push actions"}
+		}
+		if a.Path[0] != '/' {
+			return &ValidationError{Field: field("path"), Message: "path must be absolute"}
+		}
+		if (a.Content == "" && a.Source == "") || (a.Content != "" && a.Source != "") {
+			return &ValidationError{Field: field("content"), Message: "exactly one of content or source must be set for file_push actions"}
+		}
+		if a.Recursive && a.Source == "" {
+			return &ValidationError{Field: field("recursive"), Message: "recursive is only supported when source is set"}
+		}
+	default:
+		return &ValidationError{Field: field("action"), Message: "action must be one of exec, file_push"}
+	}
+
 	return nil
 }
 

--- a/internal/incus/client.go
+++ b/internal/incus/client.go
@@ -2,12 +2,12 @@ package incus
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/abiosoft/incus-apply/internal/config"
 	"github.com/abiosoft/incus-apply/internal/resource"
-	"github.com/abiosoft/incus-apply/internal/terminal"
 )
 
 const DefaultCommandTimeout = 5 * time.Minute
@@ -37,6 +37,9 @@ type Client interface {
 	Stop(res *config.Resource) *Result
 	// Running checks if an instance is currently running.
 	Running(res *config.Resource) bool
+
+	// RunSetupAction executes an instance setup action.
+	RunSetupAction(res *config.Resource, action config.SetupAction, current, total int) *Result
 }
 
 type client struct {
@@ -101,14 +104,8 @@ func (c client) Create(res *config.Resource) *Result {
 		}
 		return result
 	}
-	// Forward stdout for instance creation to show real-time launch progress.
 	if resource.Type(prepared.Type) == resource.TypeInstance {
-		result := c.run(args, stdin)
-		// Erase the "Creating <name>" status line Incus leaves on the terminal.
-		if strings.Contains(result.Stdout, "Creating "+prepared.Name) {
-			terminal.ClearLine()
-		}
-		return result
+		return c.run(args, stdin)
 	}
 	return c.runQuiet(args, stdin)
 }
@@ -237,4 +234,60 @@ func (c client) Running(res *config.Resource) bool {
 		return false
 	}
 	return strings.ToLower(strings.TrimSpace(result.Stdout)) == "running"
+}
+
+func (c client) RunSetupAction(res *config.Resource, action config.SetupAction, current, total int) *Result {
+	progressLabel := setupProgressLabel(current, total)
+	switch action.Action {
+	case config.SetupActionExec:
+		args := []string{"exec", res.Name, "--disable-stdin", "--force-noninteractive"}
+		if action.CWD != "" {
+			args = append(args, "--cwd", action.CWD)
+		}
+		args = append(args, c.globalFlags...)
+		args = c.appendProjectFlag(args, res.Project)
+		args = append(args, "--", "sh", "-c", action.Command)
+		return c.runWithProgress(args, nil, progressLabel)
+	case config.SetupActionPushFile:
+		return c.pushSetupFile(res, action, progressLabel)
+	default:
+		return &Result{Error: fmt.Errorf("unsupported setup action: %s", action.Action)}
+	}
+}
+
+func (c client) pushSetupFile(res *config.Resource, action config.SetupAction, progressLabel string) *Result {
+	args := []string{"file", "push"}
+	args = append(args, c.globalFlags...)
+	args = c.appendProjectFlag(args, res.Project)
+	args = append(args, "--create-dirs")
+	if action.UID != nil {
+		args = append(args, "--uid", strconv.Itoa(*action.UID))
+	}
+	if action.GID != nil {
+		args = append(args, "--gid", strconv.Itoa(*action.GID))
+	}
+	if action.Mode != "" {
+		args = append(args, "--mode", string(action.Mode))
+	}
+
+	var stdin []byte
+	if action.Content != "" {
+		args = append(args, "-")
+		stdin = []byte(action.Content)
+	} else {
+		if err := config.ValidateSetupSource(action, res.SourceFile); err != nil {
+			return &Result{Error: err}
+		}
+		resolved, err := config.ResolveSetupSourcePath(action.Source, res.SourceFile)
+		if err != nil {
+			return &Result{Error: err}
+		}
+		if action.Recursive {
+			args = append(args, "--recursive")
+		}
+		args = append(args, resolved)
+	}
+
+	args = append(args, res.Name+action.Path)
+	return c.runWithProgress(args, stdin, progressLabel)
 }

--- a/internal/incus/diff.go
+++ b/internal/incus/diff.go
@@ -86,7 +86,7 @@ func DiffWithIndent(current, desired, indent string) (string, error) {
 		return "", nil
 	}
 
-	return formatChanges(changes, indent, defaultMaxInlineDiffWidth), nil
+	return formatChanges(changes, indent, defaultMaxInlineDiffWidth, false), nil
 }
 
 // HasChanges checks if there are any differences between current and desired config.

--- a/internal/incus/exec.go
+++ b/internal/incus/exec.go
@@ -9,21 +9,27 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
+
+	"github.com/abiosoft/incus-apply/internal/terminal"
 )
 
-// run executes an incus command, forwarding stdout to the terminal for
-// real-time progress while still capturing it for result inspection.
+// run executes an incus command while showing transient progress in interactive terminals.
 func (c client) run(args []string, stdin []byte) *Result {
-	return c.execCmd(args, stdin, true)
+	return c.execCmd(args, stdin, false)
 }
 
-// runQuiet executes an incus command capturing all output without forwarding.
+// runQuiet executes an incus command while still capturing all output.
 func (c client) runQuiet(args []string, stdin []byte) *Result {
 	return c.execCmd(args, stdin, false)
 }
 
+func (c client) runWithProgress(args []string, stdin []byte, progressLabel string) *Result {
+	return c.execCmd(args, stdin, true, progressLabel)
+}
+
 // execCmd is the shared implementation for run and runQuiet.
-func (c client) execCmd(args []string, stdin []byte, forwardStdout bool) *Result {
+func (c client) execCmd(args []string, stdin []byte, showProgress bool, progressLabel ...string) *Result {
 	ctx := context.Background()
 	cancel := func() {}
 	if c.timeout > 0 {
@@ -38,18 +44,31 @@ func (c client) execCmd(args []string, stdin []byte, forwardStdout bool) *Result
 	}
 
 	var stdout, stderr bytes.Buffer
-	if forwardStdout {
-		cmd.Stdout = io.MultiWriter(&stdout, os.Stdout)
-	} else {
-		cmd.Stdout = &stdout
+	stdoutWriter := io.Writer(&stdout)
+	stderrWriter := io.Writer(&stderr)
+	var progress *progressWriter
+	if showProgress {
+		label := ""
+		if len(progressLabel) > 0 {
+			label = progressLabel[0]
+		}
+		progress = newTerminalProgressWriter(label)
 	}
-	cmd.Stderr = &stderr
+	if progress != nil {
+		stdoutWriter = io.MultiWriter(&stdout, progress)
+		stderrWriter = io.MultiWriter(&stderr, progress)
+	}
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
 
 	if stdin != nil {
 		cmd.Stdin = bytes.NewReader(stdin)
 	}
 
 	err := cmd.Run()
+	if progress != nil {
+		progress.Finish()
+	}
 
 	result := &Result{
 		Command: "incus " + strings.Join(args, " "),
@@ -68,4 +87,77 @@ func (c client) execCmd(args []string, stdin []byte, forwardStdout bool) *Result
 		result.Error = fmt.Errorf("%w: %s", err, strings.TrimSpace(result.Stderr))
 	}
 	return result
+}
+
+type progressWriter struct {
+	mu       sync.Mutex
+	line     strings.Builder
+	shown    bool
+	onUpdate func(string)
+	onClear  func()
+}
+
+func newProgressWriter(onUpdate func(string), onClear func()) *progressWriter {
+	return &progressWriter{onUpdate: onUpdate, onClear: onClear}
+}
+
+func newTerminalProgressWriter(prefix string) *progressWriter {
+	if !terminal.IsTerminal(os.Stdout) {
+		return nil
+	}
+	return newProgressWriter(func(text string) {
+		terminal.RewriteLine(prefix + text)
+	}, terminal.ClearCurrentLine)
+}
+
+func setupProgressLabel(current, total int) string {
+	if current <= 0 || total <= 0 {
+		return "  └─ running setup... "
+	}
+	return fmt.Sprintf("  └─ running setup %d of %d... ", current, total)
+}
+
+func (w *progressWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for _, b := range p {
+		switch b {
+		case '\r', '\n':
+			w.flushLocked()
+		default:
+			w.line.WriteByte(b)
+		}
+	}
+	if w.line.Len() > 0 {
+		w.updateLocked(w.line.String())
+	}
+	return len(p), nil
+}
+
+func (w *progressWriter) Finish() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.line.Reset()
+	if w.shown && w.onClear != nil {
+		w.onClear()
+		w.shown = false
+	}
+}
+
+func (w *progressWriter) flushLocked() {
+	if w.line.Len() == 0 {
+		return
+	}
+	w.updateLocked(w.line.String())
+	w.line.Reset()
+}
+
+func (w *progressWriter) updateLocked(text string) {
+	if text == "" || w.onUpdate == nil {
+		return
+	}
+	w.onUpdate(text)
+	w.shown = true
 }

--- a/internal/incus/exec_test.go
+++ b/internal/incus/exec_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/abiosoft/incus-apply/internal/config"
 )
 
 func TestExecCmdTimeout(t *testing.T) {
@@ -28,5 +30,88 @@ func TestExecCmdTimeout(t *testing.T) {
 	}
 	if !strings.Contains(result.Error.Error(), "timed out") {
 		t.Fatalf("timeout error = %q, want to contain %q", result.Error.Error(), "timed out")
+	}
+}
+
+func TestRunSetupActionExecUsesShellAndNonInteractive(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "incus")
+	script := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	res := &config.Resource{Base: config.Base{Type: "instance", Name: "web"}}
+	action := config.SetupAction{Action: config.SetupActionExec, When: config.SetupWhenAlways, CWD: "/srv/app", Command: "echo hello"}
+	result := client{}.RunSetupAction(res, action, 1, 1)
+	if result.Error != nil {
+		t.Fatalf("RunSetupAction() error = %v", result.Error)
+	}
+	if !strings.Contains(result.Command, "exec web --disable-stdin --force-noninteractive --cwd /srv/app -- sh -c echo hello") {
+		t.Fatalf("command = %q, want non-interactive shell exec with cwd", result.Command)
+	}
+}
+
+func TestRunSetupActionPushFileResolvesRelativeSource(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "incus")
+	script := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	configPath := filepath.Join(dir, "instance.incus.yaml")
+	sourcePath := filepath.Join(dir, "Caddyfile")
+	if err := os.WriteFile(sourcePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	res := &config.Resource{Base: config.Base{Type: "instance", Name: "web", SourceFile: configPath}}
+	action := config.SetupAction{Action: config.SetupActionPushFile, When: config.SetupWhenUpdate, Path: "/etc/caddy/Caddyfile", Source: "./Caddyfile", Recursive: true}
+
+	result := client{}.RunSetupAction(res, action, 1, 1)
+	if result.Error != nil {
+		t.Fatalf("RunSetupAction() error = %v", result.Error)
+	}
+	if !strings.Contains(result.Command, sourcePath) {
+		t.Fatalf("command = %q, want resolved absolute source path", result.Command)
+	}
+	if !strings.Contains(result.Command, "file push --create-dirs --recursive ") {
+		t.Fatalf("command = %q, want file push command with recursive flag", result.Command)
+	}
+	if !strings.Contains(result.Command, " web/etc/caddy/Caddyfile") {
+		t.Fatalf("command = %q, want instance target path", result.Command)
+	}
+}
+
+func TestProgressWriterShowsLastLineAndClears(t *testing.T) {
+	var updates []string
+	cleared := 0
+	prefix := setupProgressLabel(1, 3)
+	writer := newProgressWriter(
+		func(text string) { updates = append(updates, prefix+text) },
+		func() { cleared++ },
+	)
+
+	if _, err := writer.Write([]byte("Downloading\nInstalling")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	writer.Finish()
+
+	if len(updates) == 0 {
+		t.Fatal("updates = 0, want progress updates")
+	}
+	if updates[len(updates)-1] != prefix+"Installing" {
+		t.Fatalf("last update = %q, want %q", updates[len(updates)-1], prefix+"Installing")
+	}
+	if cleared != 1 {
+		t.Fatalf("cleared = %d, want 1", cleared)
+	}
+}
+
+func TestSetupProgressLabelIncludesPosition(t *testing.T) {
+	if got := setupProgressLabel(1, 3); got != "  └─ running setup 1 of 3... " {
+		t.Fatalf("setupProgressLabel() = %q, want %q", got, "  └─ running setup 1 of 3... ")
 	}
 }

--- a/internal/incus/format.go
+++ b/internal/incus/format.go
@@ -28,6 +28,12 @@ func FormatDiffChanges(changes []DiffChange, indent string) string {
 
 // FormatDiffChangesWithWidth renders a []DiffChange to a human-readable string with the given indent and max inline width.
 func FormatDiffChangesWithWidth(changes []DiffChange, indent string, maxWidth int) string {
+	return FormatDiffChangesWithWidthAndTrailing(changes, indent, maxWidth, false)
+}
+
+// FormatDiffChangesWithWidthAndTrailing renders a []DiffChange to a human-readable string with the given indent and max inline width.
+// When hasTrailingLine is true, the final diff entry uses a branch connector because another sibling line will follow.
+func FormatDiffChangesWithWidthAndTrailing(changes []DiffChange, indent string, maxWidth int, hasTrailingLine bool) string {
 	if maxWidth <= 0 {
 		maxWidth = defaultMaxInlineDiffWidth
 	}
@@ -41,17 +47,17 @@ func FormatDiffChangesWithWidth(changes []DiffChange, indent string, maxWidth in
 			isRemove: dc.Action == "remove",
 		}
 	}
-	return formatChanges(raw, indent, maxWidth)
+	return formatChanges(raw, indent, maxWidth, hasTrailingLine)
 }
 
 // formatChanges formats the list of changes for display with tree structure.
 // The indent prefix is prepended to each line.
-func formatChanges(changes []change, indent string, maxWidth int) string {
+func formatChanges(changes []change, indent string, maxWidth int, hasTrailingLine bool) string {
 	var result strings.Builder
 
 	for i, c := range changes {
 		tree := treeBranch
-		if i == len(changes)-1 {
+		if i == len(changes)-1 && !hasTrailingLine {
 			tree = treeLast
 		}
 

--- a/internal/incus/managed.go
+++ b/internal/incus/managed.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"strconv"
 	"strings"
 
 	"github.com/abiosoft/incus-apply/internal/config"
@@ -41,7 +42,15 @@ func DiffResource(currentYAML string, desired *config.Resource) ([]DiffChange, M
 			return nil, status, err
 		}
 		changes, err := DiffChanges(status.Snapshot, desiredSnapshot)
-		status.UnsupportedChanges = unsupportedChanges(desired.Type, changes)
+		previousState, parseErr := parseYAMLToMap(status.Snapshot, "stored incus-apply state")
+		if parseErr != nil {
+			return nil, status, parseErr
+		}
+		desiredState, parseErr := parseYAMLToMap(desiredSnapshot, "desired managed state")
+		if parseErr != nil {
+			return nil, status, parseErr
+		}
+		status.UnsupportedChanges = unsupportedChanges(desired.Type, changes, previousState, desiredState)
 		if len(status.UnsupportedChanges) > 0 {
 			status.Warning = ManagementWarningRecreate
 		}
@@ -130,6 +139,17 @@ func managedSnapshot(res *config.Resource) (string, error) {
 	}
 	if res.Ports != nil {
 		state["ports"] = res.Ports
+	}
+	if len(res.Setup) > 0 {
+		setupState := make([]any, 0, len(res.Setup))
+		for _, action := range res.Setup {
+			entry, err := config.SetupActionSnapshot(action, res.SourceFile)
+			if err != nil {
+				return "", fmt.Errorf("encoding setup state: %w", err)
+			}
+			setupState = append(setupState, entry)
+		}
+		state["setup"] = setupState
 	}
 
 	data, err := json.Marshal(state)
@@ -318,23 +338,68 @@ func applyTrackingState(current map[string]any, snapshot string) {
 	current["config"] = currentConfig
 }
 
-func unsupportedChanges(resourceType string, changes []DiffChange) []DiffChange {
+func unsupportedChanges(resourceType string, changes []DiffChange, previousState, desiredState map[string]any) []DiffChange {
 	fields := createOnlyFields(resourceType)
-	if len(fields) == 0 {
+	if len(fields) == 0 && resourceType != "instance" {
 		return nil
 	}
 
 	var unsupported []DiffChange
 	for _, change := range changes {
-		root := change.Path
-		if idx := strings.Index(root, "."); idx >= 0 {
-			root = root[:idx]
-		}
-		if fields[root] {
+		root := rootPath(change.Path)
+		if fields[root] || isCreateOnlySetupChange(change.Path, previousState, desiredState) {
 			unsupported = append(unsupported, change)
 		}
 	}
 	return unsupported
+}
+
+func rootPath(path string) string {
+	end := len(path)
+	if idx := strings.Index(path, "."); idx >= 0 && idx < end {
+		end = idx
+	}
+	if idx := strings.Index(path, "["); idx >= 0 && idx < end {
+		end = idx
+	}
+	return path[:end]
+}
+
+func isCreateOnlySetupChange(path string, previousState, desiredState map[string]any) bool {
+	if rootPath(path) != "setup" {
+		return false
+	}
+	index, ok := setupIndex(path)
+	if !ok {
+		return false
+	}
+	return setupWhen(previousState, index) == string(config.SetupWhenCreate) || setupWhen(desiredState, index) == string(config.SetupWhenCreate)
+}
+
+func setupIndex(path string) (int, bool) {
+	if !strings.HasPrefix(path, "setup[") {
+		return 0, false
+	}
+	start := len("setup[")
+	end := strings.Index(path[start:], "]")
+	if end < 0 {
+		return 0, false
+	}
+	index, err := strconv.Atoi(path[start : start+end])
+	if err != nil {
+		return 0, false
+	}
+	return index, true
+}
+
+func setupWhen(state map[string]any, index int) string {
+	entries, _ := state["setup"].([]any)
+	if index < 0 || index >= len(entries) {
+		return ""
+	}
+	entry, _ := entries[index].(map[string]any)
+	when, _ := entry["when"].(string)
+	return when
 }
 
 func createOnlyFields(resourceType string) map[string]bool {

--- a/internal/incus/merge_test.go
+++ b/internal/incus/merge_test.go
@@ -1,6 +1,7 @@
 package incus
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -41,6 +42,114 @@ func TestDesiredForApply_AddsTrackingState(t *testing.T) {
 	var parsed map[string]any
 	if err := yaml.Unmarshal([]byte(snapshot), &parsed); err != nil {
 		t.Fatalf("snapshot should remain parseable as yaml/json, got error %v", err)
+	}
+}
+
+func TestDesiredForApply_IncludesSetupSourceReference(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "instance.incus.yaml")
+	res := &config.Resource{
+		Base: config.Base{Type: "instance", Name: "test", SourceFile: configPath},
+		InstanceFields: config.InstanceFields{
+			Image: "images:alpine/3.19",
+			Setup: []config.SetupAction{{
+				Action:    config.SetupActionPushFile,
+				When:      config.SetupWhenUpdate,
+				Path:      "/etc/caddy/Caddyfile",
+				Source:    "./Caddyfile",
+				Recursive: true,
+			}},
+		},
+	}
+
+	_, snapshot, err := desiredForApply(res)
+	if err != nil {
+		t.Fatalf("desiredForApply() error = %v", err)
+	}
+	if !strings.Contains(snapshot, "\"source\":\"./Caddyfile\"") {
+		t.Fatalf("snapshot = %q, want relative source preserved", snapshot)
+	}
+	if !strings.Contains(snapshot, "\"recursive\":true") {
+		t.Fatalf("snapshot = %q, want recursive flag preserved", snapshot)
+	}
+}
+
+func TestDesiredForApply_HashesInlineSetupContent(t *testing.T) {
+	res := &config.Resource{
+		Base: config.Base{Type: "instance", Name: "test"},
+		InstanceFields: config.InstanceFields{
+			Image: "images:alpine/3.19",
+			Setup: []config.SetupAction{{
+				Action:  config.SetupActionPushFile,
+				When:    config.SetupWhenUpdate,
+				Path:    "/etc/app.conf",
+				Content: "hello world",
+			}},
+		},
+	}
+
+	_, snapshot, err := desiredForApply(res)
+	if err != nil {
+		t.Fatalf("desiredForApply() error = %v", err)
+	}
+	if strings.Contains(snapshot, "hello world") {
+		t.Fatalf("snapshot = %q, want raw inline content omitted", snapshot)
+	}
+	if !strings.Contains(snapshot, "\"content\":\"hash: b94d27b9934d3e08a52e52d711\"") {
+		t.Fatalf("snapshot = %q, want inline content hash recorded", snapshot)
+	}
+}
+
+func TestDesiredForApply_HashesSetupCommand(t *testing.T) {
+	res := &config.Resource{
+		Base: config.Base{Type: "instance", Name: "test"},
+		InstanceFields: config.InstanceFields{
+			Image: "images:alpine/3.19",
+			Setup: []config.SetupAction{{
+				Action:  config.SetupActionExec,
+				When:    config.SetupWhenAlways,
+				Command: "echo hello world",
+			}},
+		},
+	}
+
+	_, snapshot, err := desiredForApply(res)
+	if err != nil {
+		t.Fatalf("desiredForApply() error = %v", err)
+	}
+	if strings.Contains(snapshot, "echo hello world") {
+		t.Fatalf("snapshot = %q, want raw command omitted", snapshot)
+	}
+	if !strings.Contains(snapshot, "\"command\":\"hash: 5e9f1ed0cbd05609e29817be16\"") {
+		t.Fatalf("snapshot = %q, want command hash recorded", snapshot)
+	}
+}
+
+func TestDiffResource_CreateSetupChangeRequiresRecreate(t *testing.T) {
+	current := "config:\n  user.incus-apply.created: \"true\"\n  user.incus-apply.current: '{\"image\":\"images:alpine/3.19\",\"setup\":[{\"action\":\"exec\",\"when\":\"create\",\"command\":\"hash: 819b561be4b01d042acf9c1528\"}]}'\n"
+	desired := &config.Resource{
+		Base: config.Base{Type: "instance", Name: "web"},
+		InstanceFields: config.InstanceFields{
+			Image: "images:alpine/3.19",
+			Setup: []config.SetupAction{{
+				Action:  config.SetupActionExec,
+				When:    config.SetupWhenCreate,
+				Command: "echo new",
+			}},
+		},
+	}
+
+	changes, status, err := DiffResource(current, desired)
+	if err != nil {
+		t.Fatalf("DiffResource() error = %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatal("changes = 0, want setup diff")
+	}
+	if status.Warning != ManagementWarningRecreate {
+		t.Fatalf("warning = %q, want %q", status.Warning, ManagementWarningRecreate)
+	}
+	if len(status.UnsupportedChanges) == 0 {
+		t.Fatal("unsupported changes = 0, want recreate-required setup change")
 	}
 }
 

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -57,6 +57,7 @@ func (r TextRenderer) Render(output apply.Output) error {
 		return nil
 	}
 
+	terminal.ClearCurrentLine()
 	r.println()
 	r.printf("Found %d %s in %d %s.\n",
 		output.ResourceCount, plural("resource", output.ResourceCount),
@@ -86,7 +87,7 @@ func (r TextRenderer) Render(output apply.Output) error {
 			for _, item := range group.Items {
 				r.printf("%s    %s %s%s\n", color, prefix, item.ResourceID, colorReset)
 				if len(item.Changes) > 0 {
-					r.print(incus.FormatDiffChangesWithWidth(item.Changes, "      ", maxWidth))
+					r.print(incus.FormatDiffChangesWithWidthAndTrailing(item.Changes, "      ", maxWidth, item.Note != ""))
 				}
 				if item.Note != "" {
 					r.printf("      └─ %s\n", item.Note)
@@ -127,6 +128,7 @@ func NewJSONRenderer() *JSONRenderer {
 
 // Render outputs the preview results as JSON.
 func (r JSONRenderer) Render(output apply.Output) error {
+	terminal.ClearCurrentLine()
 	encoder := json.NewEncoder(r.Writer)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(output)

--- a/internal/renderer/renderer_test.go
+++ b/internal/renderer/renderer_test.go
@@ -85,6 +85,41 @@ func TestTextRenderer_Render(t *testing.T) {
 	}
 }
 
+func TestTextRenderer_RenderNoteAfterChangesUsesTreeBranch(t *testing.T) {
+	var buf bytes.Buffer
+	r := &TextRenderer{Writer: &buf}
+
+	output := apply.Output{
+		FileCount:     1,
+		ResourceCount: 1,
+		Groups: []apply.OutputGroup{{
+			Action: apply.ActionReplace,
+			Items: []apply.OutputItem{{
+				ResourceID: "default:instance/wordpress",
+				Changes: []incus.DiffChange{{
+					Path:   "setup",
+					Old:    []any{map[string]any{"action": "exec"}},
+					New:    []any{map[string]any{"action": "exec"}, map[string]any{"action": "file_push"}},
+					Action: "modify",
+				}},
+				Note: "setup, recreate required",
+			}},
+		}},
+	}
+
+	if err := r.Render(output); err != nil {
+		t.Fatal(err)
+	}
+
+	result := buf.String()
+	if !strings.Contains(result, "      ├─ setup:") {
+		t.Fatalf("expected change line to use branch connector when note follows, got %q", result)
+	}
+	if !strings.Contains(result, "      └─ setup, recreate required") {
+		t.Fatalf("expected note line to use last connector, got %q", result)
+	}
+}
+
 func TestTextRenderer_Quiet(t *testing.T) {
 	var buf bytes.Buffer
 	r := &TextRenderer{Writer: &buf, Quiet: true}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -36,6 +36,28 @@ func ClearLine() {
 	}
 }
 
+// ClearCurrentLine erases the active line without moving the cursor vertically.
+// No-op when stdout is not a real terminal.
+func ClearCurrentLine() {
+	if IsTerminal(os.Stdout) {
+		print("\r\033[2K")
+	}
+}
+
+// RewriteLine replaces the current line with text.
+// No-op when stdout is not a real terminal.
+func RewriteLine(text string) {
+	if !IsTerminal(os.Stdout) {
+		return
+	}
+
+	width := Width(os.Stdout, 0)
+	if width > 4 && len(text) > width-1 {
+		text = text[:width-4] + "..."
+	}
+	print("\r\033[2K" + text)
+}
+
 // ConfirmPrompt prompts the user for confirmation. Returns true if accepted.
 func ConfirmPrompt(prompt string) bool {
 	fmt.Println()

--- a/schema/incus-apply.schema.json
+++ b/schema/incus-apply.schema.json
@@ -108,8 +108,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -239,8 +296,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -370,8 +484,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -501,8 +672,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -633,8 +861,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -764,8 +1049,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -895,8 +1237,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -1026,8 +1425,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -1157,8 +1613,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -1288,8 +1801,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {
@@ -1419,8 +1989,65 @@
               "description": "Incus project (can be overridden by --project flag)",
               "type": "string"
             },
+            "setup": {
+              "description": "Setup actions to run against an instance after create, update, or on every apply",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "description": "Setup action type",
+                    "type": "string"
+                  },
+                  "command": {
+                    "description": "Shell command to execute inside the instance",
+                    "type": "string"
+                  },
+                  "content": {
+                    "description": "Inline file content to push into the instance",
+                    "type": "string"
+                  },
+                  "cwd": {
+                    "description": "Working directory to use for an exec setup action",
+                    "type": "string"
+                  },
+                  "gid": {
+                    "description": "File owner gid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "description": "File mode to set when pushing a file",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Absolute destination path inside the instance for a file_push action",
+                    "type": "string"
+                  },
+                  "recursive": {
+                    "description": "Pass --recursive to incus file push for a file_push setup action",
+                    "type": "boolean"
+                  },
+                  "skip": {
+                    "description": "If true, the setup action is skipped",
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "File owner uid to set when pushing a file",
+                    "type": "integer"
+                  },
+                  "when": {
+                    "description": "When to run the setup action: create, update, or always",
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "source": {
-              "description": "Source path or device for storage pool",
+              "description": "Source path or device for a storage pool, or a local file path for file_push setup actions",
               "type": "string"
             },
             "storage": {


### PR DESCRIPTION
## Summary

Add first-class `setup` support for `type: instance` resources so post-create and post-update actions can be declared directly in `incus-apply` config.

This introduces:
- `setup` actions on instances
- `exec` actions run with `incus exec --disable-stdin --force-noninteractive -- sh -c`
- `file_push` actions for inline content or local source paths
- `when: create | update | always`
- `skip: true` support
- relative `source` resolution from the owning config file
- `recursive: true` support for directory pushes
- managed-state snapshotting for setup actions
- setup-aware preview/diff output
- transient setup progress output during apply

## Example

```yaml
type: instance
name: web
image: images:ubuntu/24.04

setup:
  - action: exec
    when: create
    cwd: /root
    command: |
      apt-get update
      apt-get install -y caddy

  - action: file_push
    when: update
    path: /etc/caddy/Caddyfile
    mode: "0644"
    content: |
      :80 {
        respond "hello from incus-apply"
      }

  - action: exec
    when: always
    command: systemctl restart caddy
```

## Notes

- `exec` actions run as root inside the instance.
- `file_push` requires exactly one of `content` or `source`.
- `source` paths may be relative to the config file location.
- Changes to `when: create` setup actions are treated as recreate-required for managed instances.
