### PR TITLE
dev: add nix flake

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -4,14 +4,16 @@ Use this section to install `incus-apply`, apply your first resource, and unders
 
 ## Installation
 
-### Install a release binary
+### Linux / MacOS
+
+#### Install a release binary
 
 ```bash
 curl -LO https://github.com/abiosoft/incus-apply/releases/latest/download/incus-apply-$(uname)-$(uname -m)
 sudo install incus-apply-$(uname)-$(uname -m) /usr/local/bin/incus-apply
 ```
 
-### Or build from source
+#### Or build from source
 
 ```bash
 git clone https://github.com/abiosoft/incus-apply
@@ -19,6 +21,43 @@ cd incus-apply
 make
 sudo make install
 ```
+
+### Nix / NixOS
+
+[Flake-enabled systems](https://wiki.nixos.org/wiki/Flakes#Enabling_flakes_permanently) can try incus-apply directly with:
+```bash
+nix run github:abiosoft/incus-apply
+```
+
+To pass arguments, separate them with `--`:
+```bash
+nix run github:abiosoft/incus-apply -- debian.yaml
+```
+
+To install it, use the NixOS module. First add incus-apply to your flake inputs:
+```nix
+inputs.incus-apply.url = "github:abiosoft/incus-apply";
+inputs.incus-apply.inputs.nixpkgs.follows = "nixpkgs";
+```
+
+Then import the module in your `nixosConfigurations` and enable it:
+```nix
+{
+  outputs = { self, nixpkgs, incus-apply, ... }: {
+    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ./configuration.nix
+        incus-apply.nixosModules.default
+        { programs.incus-apply.enable = true; }
+      ];
+    };
+  };
+}
+```
+
+This installs the `incus-apply` binary system-wide.
+
 
 ## Quick start
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780336545,
+        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -36,5 +36,24 @@
           };
         };
       }
-    );
+    )
+    // {
+      nixosModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.incus-apply;
+        in
+        {
+          options.programs.incus-apply.enable = lib.mkEnableOption "incus-apply, declarative configuration management for Incus";
+
+          config = lib.mkIf cfg.enable {
+            environment.systemPackages = [ self.packages.${pkgs.system}.default ];
+          };
+        };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,12 @@
           src = ./.;
           vendorHash = "sha256-u+nl3P7YNl+3DJIXo7pnDKF4PkoYLaHf3B1LqF9b+V8=";
 
+          ldflags = [
+            "-X main.version=${self.shortRev or self.dirtyShortRev or "dev"}"
+            "-X main.commit=${self.rev or self.dirtyRev or "none"}"
+            "-X main.date=${self.lastModifiedDate or "unknown"}"
+          ];
+
           meta = {
             description = "Declarative configuration management for Incus";
             homepage = "https://github.com/abiosoft/incus-apply";

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,4 @@
 {
-  description = "Declarative configuration management for Incus";
-
   inputs = {
     nixpkgs.url = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
@@ -24,6 +22,12 @@
           name = "incus-apply";
           src = ./.;
           vendorHash = "sha256-u+nl3P7YNl+3DJIXo7pnDKF4PkoYLaHf3B1LqF9b+V8=";
+
+          meta = {
+            description = "Declarative configuration management for Incus";
+            homepage = "https://github.com/abiosoft/incus-apply";
+            mainProgram = "incus-apply";
+          };
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "Declarative configuration management for Incus";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages.default = pkgs.buildGo126Module {
+          pname = "incus-apply";
+          name = "incus-apply";
+          src = ./.;
+          vendorHash = "sha256-u+nl3P7YNl+3DJIXo7pnDKF4PkoYLaHf3B1LqF9b+V8=";
+        };
+      }
+    );
+}


### PR DESCRIPTION
I took the liberty of packaging this module as a Nix flake.  
This would allow Nix / NixOS users to try out the program like so:  
```bash
$ nix run github:abiosoft/incus-apply
```
Currently, I was able to test it with my fork:
```bash
$ nix run github:edorgeville/incus-apply/add-nix-flake --refresh -- --version
incus-apply version ec6eb53
git commit: ec6eb53be8659f627cb9ea2be899a5b92a8213fa
build date: 20260602161447
```

If you think this would deserve a place in the repository, please also let me know where you think the usage / installation documentation should go, maybe a dedicated NixOS page or directly in the Getting Started section.  

Cheers