### PR TITLE
dev: resolve relative disk device sources

### DIFF
--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -12,6 +12,27 @@ This page contains the field reference for `incus-apply` resource documents.
 | `devices` | map | Device configurations. |
 | `description` | string | Resource description. |
 
+### Devices
+
+Devices follow the Incus device schema (`type: disk`, `type: nic`, etc.).
+
+For `disk` devices without a `pool` key, a `source` path containing a path separator (e.g. `./volumes/volume1`) is resolved against the directory of the config file. Plain names such as `vol1` or `agent:config` reference a storage volume or a special Incus value and are left untouched. Use a `pool` key to reference a storage volume instead.
+
+When the resource targets a remote server, a relative `source` cannot be resolved against the local config file and is rejected with an error; use an absolute path valid on the target server.
+
+```yaml
+kind: instance
+name: test3
+image: images:fedora/44
+profiles:
+  - default
+devices:
+  volume1:
+    type: disk
+    source: ./volumes/volume1
+    path: /mnt/volume1
+```
+
 ## Remotes
 
 Incus supports named remote servers. By default, `incus-apply` targets whichever remote is configured as the default in the `incus` CLI.

--- a/internal/apply/executor.go
+++ b/internal/apply/executor.go
@@ -66,6 +66,18 @@ func (a *defaultExecutor) loadAndValidate() ([]*config.Resource, error) {
 	return resources, nil
 }
 
+// resolveDiskSources resolves relative disk device sources for all resources.
+// Must be called after applyRemoteOverride so that res.Remote reflects the
+// effective target server.
+func resolveDiskSources(resources []*config.Resource) error {
+	for _, res := range resources {
+		if err := resolveRelativeDiskSources(res); err != nil {
+			return fmt.Errorf("resolving relative disk sources for %s %q in %s: %w", res.Type, res.Name, res.SourceFile, err)
+		}
+	}
+	return nil
+}
+
 // Upsert creates or updates resources based on config.
 func (a *defaultExecutor) Upsert() error {
 	resources, err := a.loadAndValidate()
@@ -74,6 +86,9 @@ func (a *defaultExecutor) Upsert() error {
 	}
 	if resources == nil {
 		return nil
+	}
+	if err := resolveDiskSources(resources); err != nil {
+		return err
 	}
 	if a.opts.Select {
 		resources, err = a.doMultiSelect(resources)
@@ -190,6 +205,9 @@ func (a *defaultExecutor) Reset() error {
 	}
 	if resources == nil {
 		return nil
+	}
+	if err := resolveDiskSources(resources); err != nil {
+		return err
 	}
 	if a.opts.Select {
 		resources, err = a.doMultiSelect(resources)

--- a/internal/apply/loader.go
+++ b/internal/apply/loader.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/abiosoft/incus-apply/internal/config"
@@ -218,4 +219,59 @@ func setPreviewRedaction(res *config.Resource) {
 		return
 	}
 	res.PreviewRedactPrefixes = nil
+}
+
+// sourceFileDir returns the absolute directory of the config file a resource
+// came from. Sources without a resolvable filesystem location (stdin, URLs)
+// return an error since relative paths cannot be resolved against them.
+func sourceFileDir(sourceFile string) (string, error) {
+	switch {
+	case sourceFile == "" || sourceFile == "stdin":
+		return "", fmt.Errorf("cannot resolve relative disk source: configuration comes from stdin")
+	case isURL(sourceFile):
+		return "", fmt.Errorf("cannot resolve relative disk source: configuration comes from URL %s", sourceFile)
+	default:
+		abs, err := filepath.Abs(sourceFile)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Dir(abs), nil
+	}
+}
+
+// resolveRelativeDiskSources rewrites relative `source` paths of disk devices
+// to absolute paths relative to the directory of the config file. Only sources
+// containing a path separator (e.g. `./volumes/volume1`) are resolved; plain
+// names (`vol1`, `agent:config`) and devices with a `pool` key reference
+// storage volumes or special Incus values and are left untouched.
+//
+// When the resource targets a remote server (res.Remote != ""), a relative
+// source is rejected with an error since the path would be interpreted by the
+// target server rather than the local config file location.
+func resolveRelativeDiskSources(res *config.Resource) error {
+	baseDir := ""
+	for _, device := range res.Devices {
+		if deviceType, _ := device["type"].(string); deviceType != "disk" {
+			continue
+		}
+		if _, hasPool := device["pool"]; hasPool {
+			continue
+		}
+		source, ok := device["source"].(string)
+		if !ok || source == "" || filepath.IsAbs(source) || !strings.Contains(source, "/") {
+			continue
+		}
+		if res.Remote != "" {
+			return fmt.Errorf("relative disk source %q is not supported with remote %q; use an absolute path valid on the target server", source, res.Remote)
+		}
+		if baseDir == "" {
+			dir, err := sourceFileDir(res.SourceFile)
+			if err != nil {
+				return err
+			}
+			baseDir = dir
+		}
+		device["source"] = filepath.Join(baseDir, source)
+	}
+	return nil
 }

--- a/internal/apply/loader_test.go
+++ b/internal/apply/loader_test.go
@@ -1,6 +1,8 @@
 package apply
 
 import (
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/abiosoft/incus-apply/internal/config"
@@ -74,6 +76,160 @@ func TestResolveAndInterpolateScopesVarsPerFile(t *testing.T) {
 	}
 	if len(resources[1].PreviewRedactPrefixes) != 1 || resources[1].PreviewRedactPrefixes[0] != "config.environment." {
 		t.Fatalf("resource 1 preview redact prefixes = %#v, want [config.environment.]", resources[1].PreviewRedactPrefixes)
+	}
+}
+
+func TestResolveRelativeDiskSources(t *testing.T) {
+	absDir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("filepath.Abs() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		sourceFile string
+		remote     string
+		devices    map[string]map[string]any
+		want       map[string]map[string]any
+		wantErr    bool
+	}{
+		{
+			name:       "relative source resolved against yaml directory",
+			sourceFile: "resources.yaml",
+			devices: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "./volumes/volume1", "path": "/mnt/volume1"},
+			},
+			want: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": filepath.Join(absDir, "volumes", "volume1"), "path": "/mnt/volume1"},
+			},
+		},
+		{
+			name:       "relative source without dot prefix resolved",
+			sourceFile: "resources.yaml",
+			devices: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "volumes/volume1", "path": "/mnt/volume1"},
+			},
+			want: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": filepath.Join(absDir, "volumes", "volume1"), "path": "/mnt/volume1"},
+			},
+		},
+		{
+			name:       "special agent:config value untouched",
+			sourceFile: "resources.yaml",
+			devices: map[string]map[string]any{
+				"agent": {"type": "disk", "source": "agent:config"},
+			},
+			want: map[string]map[string]any{
+				"agent": {"type": "disk", "source": "agent:config"},
+			},
+		},
+		{
+			name:       "absolute source unchanged",
+			sourceFile: "resources.yaml",
+			devices: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "/data/volume1", "path": "/mnt/volume1"},
+			},
+			want: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "/data/volume1", "path": "/mnt/volume1"},
+			},
+		},
+		{
+			name:       "storage volume with pool untouched",
+			sourceFile: "resources.yaml",
+			devices: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "vol1", "pool": "default", "path": "/mnt/volume1"},
+			},
+			want: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "vol1", "pool": "default", "path": "/mnt/volume1"},
+			},
+		},
+		{
+			name:       "non-disk device untouched",
+			sourceFile: "resources.yaml",
+			devices: map[string]map[string]any{
+				"eth0": {"type": "nic", "network": "default"},
+			},
+			want: map[string]map[string]any{
+				"eth0": {"type": "nic", "network": "default"},
+			},
+		},
+		{
+			name:       "non-string source untouched",
+			sourceFile: "resources.yaml",
+			devices: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": 42, "path": "/mnt/volume1"},
+			},
+			want: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": 42, "path": "/mnt/volume1"},
+			},
+		},
+		{
+			name:       "relative source with remote errors",
+			sourceFile: "resources.yaml",
+			remote:     "server-a",
+			devices: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "./volumes/volume1", "path": "/mnt/volume1"},
+			},
+			wantErr: true,
+		},
+		{
+			name:       "absolute source with remote ok",
+			sourceFile: "resources.yaml",
+			remote:     "server-a",
+			devices: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "/data/volume1", "path": "/mnt/volume1"},
+			},
+			want: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "/data/volume1", "path": "/mnt/volume1"},
+			},
+		},
+		{
+			name:       "agent:config with remote ok",
+			sourceFile: "resources.yaml",
+			remote:     "server-a",
+			devices: map[string]map[string]any{
+				"agent": {"type": "disk", "source": "agent:config"},
+			},
+			want: map[string]map[string]any{
+				"agent": {"type": "disk", "source": "agent:config"},
+			},
+		},
+		{
+			name:       "stdin source errors",
+			sourceFile: "stdin",
+			devices: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "./volumes/volume1", "path": "/mnt/volume1"},
+			},
+			wantErr: true,
+		},
+		{
+			name:       "url source errors",
+			sourceFile: "https://example.com/resources.yaml",
+			devices: map[string]map[string]any{
+				"volume1": {"type": "disk", "source": "./volumes/volume1", "path": "/mnt/volume1"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := &config.Resource{Base: config.Base{Type: "instance", Name: "web", SourceFile: tt.sourceFile, Remote: tt.remote, Devices: tt.devices}}
+
+			err := resolveRelativeDiskSources(res)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveRelativeDiskSources() error = %v", err)
+			}
+			if got := res.Devices; !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("devices = %#v, want %#v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Thanks for this great project. I've been using `incus-apply` for a while now
and it fits my needs perfectly.

As a long-time docker-compose user, I'm used to declaring bind mounts with
relative paths in my projects. With Incus I kept hitting the same friction:
a relative `source` on a `disk` device is resolved by the daemon against its
own working directory, which is almost never what I want. This PR makes
`incus-apply` resolve relative `source` paths against the directory of the
config file instead.

What this does:

- For `disk` devices without a `pool` key, a `source` containing a path
  separator (e.g. `./volumes/volume1`) is resolved to an absolute path
  relative to the YAML file directory.
- Plain names (`vol1`, `agent:config`) and devices with a `pool` key are left
  untouched, since they reference storage volumes or special Incus values.
- A relative `source` now fails with a clear error when the config comes from
  stdin, a URL, or targets a remote server. I took into account that Incus
  can be connected to a remote daemon, in which case a path relative to the
  local config file has no meaning.

A note on process: I tried to make this PR carefully (about 1h05 in real
time) and it was implemented and reviewed with the help of OpenCode (powered
by DeepSeek V4 Flash). I carefully reviewed the diff and tried to probe for
regressions.

I'm currently using this feature from my fork in my own projects, and I'd be
happy to switch back to upstream once it's merged. I'm open to any
refactoring or correction you may suggest.